### PR TITLE
goforit: update json format to handle nested flags

### DIFF
--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -1,10 +1,14 @@
-[
-  {
-    "Name" : "go.sun.mercury",
-    "Rate" : 1.0
-  },
-  {
-    "Name" : "go.stars.money",
-    "Rate" : 0.5
-  }
-]
+{
+  "flags" :
+    [
+      {
+        "Name" : "go.sun.mercury",
+        "Rate" : 1.0
+      },
+      {
+        "Name" : "go.stars.money",
+        "Rate" : 0.5
+      }
+    ],
+  "updated" : 1519164729.622348
+}

--- a/flags.go
+++ b/flags.go
@@ -180,7 +180,6 @@ func RefreshFlags(backend Backend) error {
 
 	refreshedFlags, err := backend.Refresh()
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 

--- a/flags.go
+++ b/flags.go
@@ -64,6 +64,10 @@ type Flag struct {
 	Rate float64
 }
 
+type JSONFormat struct {
+  Flags []Flag `json:"flags"`
+}
+
 var flags = map[string]Flag{}
 var flagsMtx = sync.RWMutex{}
 
@@ -145,12 +149,12 @@ func parseFlagsCSV(r io.Reader) (map[string]Flag, error) {
 
 func parseFlagsJSON(r io.Reader) (map[string]Flag, error) {
 	dec := json.NewDecoder(r)
-	var v []Flag
+	var v JSONFormat
 	err := dec.Decode(&v)
 	if err != nil {
 		return nil, err
 	}
-	return flagsToMap(v), nil
+	return flagsToMap(v.Flags), nil
 }
 
 // BackendFromFile is a helper function that creates a valid
@@ -176,6 +180,7 @@ func RefreshFlags(backend Backend) error {
 
 	refreshedFlags, err := backend.Refresh()
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 


### PR DESCRIPTION
Updated the JSON cache ingestion to correctly handle flags that are nested inside a larger JSON object.