### PR TITLE
add tests for JSON parsing using real file generated by upload code in QA

### DIFF
--- a/fixtures/flags_example.json
+++ b/fixtures/flags_example.json
@@ -1,14 +1,9 @@
 {
-  "flags" :
-    [
-      {
-        "Name" : "go.sun.mercury",
-        "Rate" : 1.0
-      },
-      {
-        "Name" : "go.stars.money",
-        "Rate" : 0.5
-      }
-    ],
-  "updated" : 1519164729.622348
+  "flags": [
+    {
+      "Name": "sequins.prevent_download",
+      "Rate": 0
+    }
+  ],
+  "updated": 1519247256.0626957
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -64,6 +64,41 @@ func TestParseFlagsCSV(t *testing.T) {
 	}
 }
 
+func TestParseFlagsJSON(t *testing.T) {
+	filename := filepath.Join("fixtures", "flags_example.json")
+
+	type testcase struct {
+		Name     string
+		Filename string
+		Expected []Flag
+	}
+
+	cases := []testcase{
+		{
+			Name:     "BasicExample",
+			Filename: filepath.Join("fixtures", "flags_example.json"),
+			Expected: []Flag{
+				{
+					"sequins.prevent_download",
+					0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, err := os.Open(filename)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			flags, err := parseFlagsJSON(f)
+
+			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
+		})
+	}
+}
+
 func TestEnabled(t *testing.T) {
 	const iterations = 100000
 


### PR DESCRIPTION
update flags_example.json to contain a real JSON file generated by the upload code; add a test that verifies it can parse it